### PR TITLE
Add automatic module name for Java 9 JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     </developers>
 
     <properties>
+    	<module.name>com.github.codemonstur.simplexml</module.name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
@@ -87,7 +88,18 @@
 
     <build>
         <plugins>
-
+			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-jar-plugin</artifactId>
+			    <configuration>
+			        <archive>
+			            <manifestEntries>
+			                <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
+			            </manifestEntries>
+			        </archive>
+			    </configuration>
+			</plugin>
+			
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </developers>
 
     <properties>
-    	<module.name>com.github.codemonstur.simplexml</module.name>
+        <module.name>com.github.codemonstur.simplexml</module.name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
@@ -88,18 +88,18 @@
 
     <build>
         <plugins>
-			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-jar-plugin</artifactId>
-			    <configuration>
-			        <archive>
-			            <manifestEntries>
-			                <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
-			            </manifestEntries>
-			        </archive>
-			    </configuration>
-			</plugin>
-			
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+             </plugin>
+
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
To use this library with Java 9+, it is highly recommended to add an automatic module name to the MANIFEST.MF file.

I've chosen `com.github.codemonstur.simplexml` but this can still be changed, of course.

This PR is just a small change in the `pom.xml` file.