### PR TITLE
Enforce Unix line endings for XML files during checkout.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix line endings for XML files. Otherwise tests might fail.
+*.xml           text eol=lf


### PR DESCRIPTION
My git client (on Windows) checked out the `.xml` (test) files with Windows line endings. As a result, the tests failed locally on my machine.

To prevent that, I've added a `.gitattributes` file to the project which should enforce Unix line endings for all `*.xml` files.